### PR TITLE
Updated hooks lib to beta.4 and updated example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "test",
       "version": "0.1.0",
       "dependencies": {
-        "@apollo/client": "^3.6.9",
-        "@nft/hooks": "^1.0.0-beta.2",
+        "@nft/hooks": "^1.0.0-beta.4",
         "@rainbow-me/rainbowkit": "^0.5.1",
         "@tanstack/react-query": "^4.2.3",
         "ethers": "^5.7.0",
+        "graphql-tag": "^2.12.6",
         "next": "^12.1.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -36,42 +36,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apollo/client": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-      "integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
-      },
-      "peerDependenciesMeta": {
-        "graphql-ws": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "subscriptions-transport-ws": {
-          "optional": true
-        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2965,450 +2929,6 @@
         "@types/yargs-parser": "*"
       }
     },
-    "node_modules/@jimp/bmp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-      "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "bmp-js": "^0.1.0"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/core": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-      "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "any-base": "^1.1.0",
-        "buffer": "^5.2.0",
-        "exif-parser": "^0.1.12",
-        "file-type": "^9.0.0",
-        "load-bmfont": "^1.3.1",
-        "mkdirp": "^0.5.1",
-        "phin": "^2.9.1",
-        "pixelmatch": "^4.0.2",
-        "tinycolor2": "^1.4.1"
-      }
-    },
-    "node_modules/@jimp/core/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/@jimp/custom": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-      "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/core": "^0.16.1"
-      }
-    },
-    "node_modules/@jimp/gif": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-      "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "gifwrap": "^0.9.2",
-        "omggif": "^1.0.9"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/jpeg": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-      "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "jpeg-js": "0.4.2"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-blit": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
-      "integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-blur": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
-      "integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-circle": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
-      "integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-color": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
-      "integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "tinycolor2": "^1.4.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-contain": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
-      "integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5",
-        "@jimp/plugin-scale": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-cover": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
-      "integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-crop": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5",
-        "@jimp/plugin-scale": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-crop": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
-      "integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-displace": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
-      "integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-dither": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
-      "integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-fisheye": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
-      "integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-flip": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
-      "integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-rotate": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-gaussian": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
-      "integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-invert": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
-      "integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-mask": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
-      "integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-normalize": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
-      "integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-print": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
-      "integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "load-bmfont": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-resize": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-      "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-rotate": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
-      "integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blit": ">=0.3.5",
-        "@jimp/plugin-crop": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-scale": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
-      "integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-shadow": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
-      "integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-blur": ">=0.3.5",
-        "@jimp/plugin-resize": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/plugin-threshold": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
-      "integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5",
-        "@jimp/plugin-color": ">=0.8.0",
-        "@jimp/plugin-resize": ">=0.8.0"
-      }
-    },
-    "node_modules/@jimp/plugins": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
-      "integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/plugin-blit": "^0.16.1",
-        "@jimp/plugin-blur": "^0.16.1",
-        "@jimp/plugin-circle": "^0.16.1",
-        "@jimp/plugin-color": "^0.16.1",
-        "@jimp/plugin-contain": "^0.16.1",
-        "@jimp/plugin-cover": "^0.16.1",
-        "@jimp/plugin-crop": "^0.16.1",
-        "@jimp/plugin-displace": "^0.16.1",
-        "@jimp/plugin-dither": "^0.16.1",
-        "@jimp/plugin-fisheye": "^0.16.1",
-        "@jimp/plugin-flip": "^0.16.1",
-        "@jimp/plugin-gaussian": "^0.16.1",
-        "@jimp/plugin-invert": "^0.16.1",
-        "@jimp/plugin-mask": "^0.16.1",
-        "@jimp/plugin-normalize": "^0.16.1",
-        "@jimp/plugin-print": "^0.16.1",
-        "@jimp/plugin-resize": "^0.16.1",
-        "@jimp/plugin-rotate": "^0.16.1",
-        "@jimp/plugin-scale": "^0.16.1",
-        "@jimp/plugin-shadow": "^0.16.1",
-        "@jimp/plugin-threshold": "^0.16.1",
-        "timm": "^1.6.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/png": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-      "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "pngjs": "^3.3.3"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/tiff": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-      "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "utif": "^2.0.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/types": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-      "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/bmp": "^0.16.1",
-        "@jimp/gif": "^0.16.1",
-        "@jimp/jpeg": "^0.16.1",
-        "@jimp/png": "^0.16.1",
-        "@jimp/tiff": "^0.16.1",
-        "timm": "^1.6.1"
-      },
-      "peerDependencies": {
-        "@jimp/custom": ">=0.3.5"
-      }
-    },
-    "node_modules/@jimp/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -3493,9 +3013,9 @@
       }
     },
     "node_modules/@magic-sdk/provider/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3751,9 +3271,9 @@
       }
     },
     "node_modules/@nft/email-connector": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@nft/email-connector/-/email-connector-1.0.0-beta.2.tgz",
-      "integrity": "sha512-40N4BnUUkGiVPkQIiCAA5VAmz9D45mUgObryw/zetr+/xUe7wRrS/L3lH+6H75esCrgZukpGsL8HVJZkn4RZ2Q==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nft/email-connector/-/email-connector-1.0.0-beta.4.tgz",
+      "integrity": "sha512-tp24khroV2T5FkxXi7uu7CVJZA14SgbbcOPpohtoA6jzH3XYcFKwN+5al58uv6B+oS8MJaqyoT6ny+oQdSr08Q==",
       "dependencies": {
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/magic-connector": "^6.1.9",
@@ -3774,17 +3294,16 @@
       }
     },
     "node_modules/@nft/hooks": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@nft/hooks/-/hooks-1.0.0-beta.2.tgz",
-      "integrity": "sha512-w+BsV9phA5F4BotSHl1Rr+VLkR2IayVLJe7B3JPpZseuhmoz613pxkjxzq75ARI7t2/tzKK6qRuVfMdfIZqMmA==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nft/hooks/-/hooks-1.0.0-beta.4.tgz",
+      "integrity": "sha512-nABqqFnKlo1UeFC8jIvlEnQvCzFmbH1LVRR3QD76zPL5y9F3rjBRyYq7ZopJuUm1vL5HoXxvj48dvpQ9gZlO6w==",
       "dependencies": {
-        "@apollo/client": "^3.4.16",
         "@ethersproject/abstract-provider": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.0.14",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/properties": "^5.5.0",
-        "@nft/email-connector": "^1.0.0-beta.2",
+        "@nft/email-connector": "^1.0.0-beta.4",
         "@pinata/ipfs-gateway-tools": "1.1.6",
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/core": "^6.1.9",
@@ -3793,8 +3312,7 @@
         "@web3-react/walletlink-connector": "^6.1.9",
         "bignumber.js": "^9.0.2",
         "dayjs": "^1.11.0",
-        "jimp": "^0.16.1",
-        "next": "^12.1.6",
+        "graphql-request": "^5.0.0",
         "react": "^17.0.2",
         "react-device-detect": "^1.17.0"
       }
@@ -5799,39 +5317,6 @@
         "@web3-react/types": "^6.0.7"
       }
     },
-    "node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5943,11 +5428,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -6151,6 +5631,11 @@
       "dependencies": {
         "tslib": "^2.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -6436,11 +5921,6 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
-    "node_modules/bmp-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
-    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -6595,14 +6075,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "node_modules/buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
@@ -7017,6 +6489,17 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "peer": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -7394,6 +6877,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/denodeify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
@@ -7467,11 +6958,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8549,11 +8035,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/exif-parser": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
-    },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -8756,6 +8237,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -8848,14 +8340,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-      "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -8998,6 +8482,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -9129,15 +8626,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/gifwrap": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
-      "dependencies": {
-        "image-q": "^4.0.0",
-        "omggif": "^1.0.10"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9167,15 +8655,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
       }
     },
     "node_modules/globals": {
@@ -9225,6 +8704,20 @@
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.0.0.tgz",
+      "integrity": "sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-fetch": "^3.1.5",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
       }
     },
     "node_modules/graphql-tag": {
@@ -9435,14 +8928,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -9495,19 +8980,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/image-q": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-      "dependencies": {
-        "@types/node": "16.9.1"
-      }
-    },
-    "node_modules/image-q/node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
     "node_modules/image-size": {
       "version": "0.6.3",
@@ -9763,11 +9235,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
@@ -10062,18 +9529,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
-    "node_modules/jimp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
-      "integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/custom": "^0.16.1",
-        "@jimp/plugins": "^0.16.1",
-        "@jimp/types": "^0.16.1",
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
     "node_modules/joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -10086,11 +9541,6 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
     },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
@@ -10516,21 +9966,6 @@
       "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
       "dependencies": {
         "immediate": "~3.0.5"
-      }
-    },
-    "node_modules/load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-      "dependencies": {
-        "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
       }
     },
     "node_modules/localforage": {
@@ -11633,6 +11068,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -11644,7 +11080,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11653,7 +11088,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -11668,14 +11102,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -11721,6 +11147,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -12241,11 +11668,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/omggif": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
-    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -12309,15 +11731,6 @@
       "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "dependencies": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optionator": {
@@ -12393,11 +11806,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12409,30 +11817,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/parse-bmfont-ascii": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
-    },
-    "node_modules/parse-bmfont-binary": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
-    },
-    "node_modules/parse-bmfont-xml": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-      "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-      "dependencies": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
-      }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -12506,11 +11890,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/phin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -12542,17 +11921,6 @@
       "peer": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
-      "dependencies": {
-        "pngjs": "^3.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/pngjs": {
@@ -12628,14 +11996,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12668,6 +12028,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13348,11 +12709,6 @@
       "dependencies": {
         "ret": "~0.1.10"
       }
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
@@ -14281,14 +13637,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -14379,11 +13727,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/timm": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
-    },
     "node_modules/tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -14393,14 +13736,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "node_modules/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -14484,17 +13819,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -14898,14 +14222,6 @@
         "node": ">=6.14.2"
       }
     },
-    "node_modules/utif": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
-      "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
-      "dependencies": {
-        "pako": "^1.0.5"
-      }
-    },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -15156,42 +14472,6 @@
         }
       }
     },
-    "node_modules/xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "dependencies": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "node_modules/xml-parse-from-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15262,19 +14542,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "dependencies": {
-        "zen-observable": "0.8.15"
-      }
-    },
     "node_modules/zustand": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.1.1.tgz",
@@ -15307,25 +14574,6 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@apollo/client": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-      "integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
-      "requires": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.6.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
       }
     },
     "@babel/code-frame": {
@@ -17255,338 +16503,6 @@
         }
       }
     },
-    "@jimp/bmp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.1.tgz",
-      "integrity": "sha512-iwyNYQeBawrdg/f24x3pQ5rEx+/GwjZcCXd3Kgc+ZUd+Ivia7sIqBsOnDaMZdKCBPlfW364ekexnlOqyVa0NWg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "bmp-js": "^0.1.0"
-      }
-    },
-    "@jimp/core": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.1.tgz",
-      "integrity": "sha512-la7kQia31V6kQ4q1kI/uLimu8FXx7imWVajDGtwUG8fzePLWDFJyZl0fdIXVCL1JW2nBcRHidUot6jvlRDi2+g==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "any-base": "^1.1.0",
-        "buffer": "^5.2.0",
-        "exif-parser": "^0.1.12",
-        "file-type": "^9.0.0",
-        "load-bmfont": "^1.3.1",
-        "mkdirp": "^0.5.1",
-        "phin": "^2.9.1",
-        "pixelmatch": "^4.0.2",
-        "tinycolor2": "^1.4.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
-    },
-    "@jimp/custom": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.1.tgz",
-      "integrity": "sha512-DNUAHNSiUI/j9hmbatD6WN/EBIyeq4AO0frl5ETtt51VN1SvE4t4v83ZA/V6ikxEf3hxLju4tQ5Pc3zmZkN/3A==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/core": "^0.16.1"
-      }
-    },
-    "@jimp/gif": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.1.tgz",
-      "integrity": "sha512-r/1+GzIW1D5zrP4tNrfW+3y4vqD935WBXSc8X/wm23QTY9aJO9Lw6PEdzpYCEY+SOklIFKaJYUAq/Nvgm/9ryw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "gifwrap": "^0.9.2",
-        "omggif": "^1.0.9"
-      }
-    },
-    "@jimp/jpeg": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-      "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "jpeg-js": "0.4.2"
-      }
-    },
-    "@jimp/plugin-blit": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.1.tgz",
-      "integrity": "sha512-fKFNARm32RoLSokJ8WZXHHH2CGzz6ire2n1Jh6u+XQLhk9TweT1DcLHIXwQMh8oR12KgjbgsMGvrMVlVknmOAg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-blur": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.1.tgz",
-      "integrity": "sha512-1WhuLGGj9MypFKRcPvmW45ht7nXkOKu+lg3n2VBzIB7r4kKNVchuI59bXaCYQumOLEqVK7JdB4glaDAbCQCLyw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-circle": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.1.tgz",
-      "integrity": "sha512-JK7yi1CIU7/XL8hdahjcbGA3V7c+F+Iw+mhMQhLEi7Q0tCnZ69YJBTamMiNg3fWPVfMuvWJJKOBRVpwNTuaZRg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-color": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.1.tgz",
-      "integrity": "sha512-9yQttBAO5SEFj7S6nJK54f+1BnuBG4c28q+iyzm1JjtnehjqMg6Ljw4gCSDCvoCQ3jBSYHN66pmwTV74SU1B7A==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "tinycolor2": "^1.4.1"
-      }
-    },
-    "@jimp/plugin-contain": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.1.tgz",
-      "integrity": "sha512-44F3dUIjBDHN+Ym/vEfg+jtjMjAqd2uw9nssN67/n4FdpuZUVs7E7wadKY1RRNuJO+WgcD5aDQcsvurXMETQTg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-cover": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.1.tgz",
-      "integrity": "sha512-YztWCIldBAVo0zxcQXR+a/uk3/TtYnpKU2CanOPJ7baIuDlWPsG+YE4xTsswZZc12H9Kl7CiziEbDtvF9kwA/Q==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-crop": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.1.tgz",
-      "integrity": "sha512-UQdva9oQzCVadkyo3T5Tv2CUZbf0klm2cD4cWMlASuTOYgaGaFHhT9st+kmfvXjKL8q3STkBu/zUPV6PbuV3ew==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-displace": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.1.tgz",
-      "integrity": "sha512-iVAWuz2+G6Heu8gVZksUz+4hQYpR4R0R/RtBzpWEl8ItBe7O6QjORAkhxzg+WdYLL2A/Yd4ekTpvK0/qW8hTVw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-dither": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.1.tgz",
-      "integrity": "sha512-tADKVd+HDC9EhJRUDwMvzBXPz4GLoU6s5P7xkVq46tskExYSptgj5713J5Thj3NMgH9Rsqu22jNg1H/7tr3V9Q==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-fisheye": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.1.tgz",
-      "integrity": "sha512-BWHnc5hVobviTyIRHhIy9VxI1ACf4CeSuCfURB6JZm87YuyvgQh5aX5UDKtOz/3haMHXBLP61ZBxlNpMD8CG4A==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-flip": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.1.tgz",
-      "integrity": "sha512-KdxTf0zErfZ8DyHkImDTnQBuHby+a5YFdoKI/G3GpBl3qxLBvC+PWkS2F/iN3H7wszP7/TKxTEvWL927pypT0w==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-gaussian": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.1.tgz",
-      "integrity": "sha512-u9n4wjskh3N1mSqketbL6tVcLU2S5TEaFPR40K6TDv4phPLZALi1Of7reUmYpVm8mBDHt1I6kGhuCJiWvzfGyg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-invert": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.1.tgz",
-      "integrity": "sha512-2DKuyVXANH8WDpW9NG+PYFbehzJfweZszFYyxcaewaPLN0GxvxVLOGOPP1NuUTcHkOdMFbE0nHDuB7f+sYF/2w==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-mask": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.1.tgz",
-      "integrity": "sha512-snfiqHlVuj4bSFS0v96vo2PpqCDMe4JB+O++sMo5jF5mvGcGL6AIeLo8cYqPNpdO6BZpBJ8MY5El0Veckhr39Q==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-normalize": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.1.tgz",
-      "integrity": "sha512-dOQfIOvGLKDKXPU8xXWzaUeB0nvkosHw6Xg1WhS1Z5Q0PazByhaxOQkSKgUryNN/H+X7UdbDvlyh/yHf3ITRaw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-print": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.1.tgz",
-      "integrity": "sha512-ceWgYN40jbN4cWRxixym+csyVymvrryuKBQ+zoIvN5iE6OyS+2d7Mn4zlNgumSczb9GGyZZESIgVcBDA1ezq0Q==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "load-bmfont": "^1.4.0"
-      }
-    },
-    "@jimp/plugin-resize": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.1.tgz",
-      "integrity": "sha512-u4JBLdRI7dargC04p2Ha24kofQBk3vhaf0q8FwSYgnCRwxfvh2RxvhJZk9H7Q91JZp6wgjz/SjvEAYjGCEgAwQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-rotate": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.1.tgz",
-      "integrity": "sha512-ZUU415gDQ0VjYutmVgAYYxC9Og9ixu2jAGMCU54mSMfuIlmohYfwARQmI7h4QB84M76c9hVLdONWjuo+rip/zg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-scale": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.1.tgz",
-      "integrity": "sha512-jM2QlgThIDIc4rcyughD5O7sOYezxdafg/2Xtd1csfK3z6fba3asxDwthqPZAgitrLgiKBDp6XfzC07Y/CefUw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-shadow": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.1.tgz",
-      "integrity": "sha512-MeD2Is17oKzXLnsphAa1sDstTu6nxscugxAEk3ji0GV1FohCvpHBcec0nAq6/czg4WzqfDts+fcPfC79qWmqrA==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugin-threshold": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.1.tgz",
-      "integrity": "sha512-iGW8U/wiCSR0+6syrPioVGoSzQFt4Z91SsCRbgNKTAk7D+XQv6OI78jvvYg4o0c2FOlwGhqz147HZV5utoSLxA==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1"
-      }
-    },
-    "@jimp/plugins": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.1.tgz",
-      "integrity": "sha512-c+lCqa25b+4q6mJZSetlxhMoYuiltyS+ValLzdwK/47+aYsq+kcJNl+TuxIEKf59yr9+5rkbpsPkZHLF/V7FFA==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/plugin-blit": "^0.16.1",
-        "@jimp/plugin-blur": "^0.16.1",
-        "@jimp/plugin-circle": "^0.16.1",
-        "@jimp/plugin-color": "^0.16.1",
-        "@jimp/plugin-contain": "^0.16.1",
-        "@jimp/plugin-cover": "^0.16.1",
-        "@jimp/plugin-crop": "^0.16.1",
-        "@jimp/plugin-displace": "^0.16.1",
-        "@jimp/plugin-dither": "^0.16.1",
-        "@jimp/plugin-fisheye": "^0.16.1",
-        "@jimp/plugin-flip": "^0.16.1",
-        "@jimp/plugin-gaussian": "^0.16.1",
-        "@jimp/plugin-invert": "^0.16.1",
-        "@jimp/plugin-mask": "^0.16.1",
-        "@jimp/plugin-normalize": "^0.16.1",
-        "@jimp/plugin-print": "^0.16.1",
-        "@jimp/plugin-resize": "^0.16.1",
-        "@jimp/plugin-rotate": "^0.16.1",
-        "@jimp/plugin-scale": "^0.16.1",
-        "@jimp/plugin-shadow": "^0.16.1",
-        "@jimp/plugin-threshold": "^0.16.1",
-        "timm": "^1.6.1"
-      }
-    },
-    "@jimp/png": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.1.tgz",
-      "integrity": "sha512-iyWoCxEBTW0OUWWn6SveD4LePW89kO7ZOy5sCfYeDM/oTPLpR8iMIGvZpZUz1b8kvzFr27vPst4E5rJhGjwsdw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "pngjs": "^3.3.3"
-      }
-    },
-    "@jimp/tiff": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.1.tgz",
-      "integrity": "sha512-3K3+xpJS79RmSkAvFMgqY5dhSB+/sxhwTFA9f4AVHUK0oKW+u6r52Z1L0tMXHnpbAdR9EJ+xaAl2D4x19XShkQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "utif": "^2.0.1"
-      }
-    },
-    "@jimp/types": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.1.tgz",
-      "integrity": "sha512-g1w/+NfWqiVW4CaXSJyD28JQqZtm2eyKMWPhBBDCJN9nLCN12/Az0WFF3JUAktzdsEC2KRN2AqB1a2oMZBNgSQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/bmp": "^0.16.1",
-        "@jimp/gif": "^0.16.1",
-        "@jimp/jpeg": "^0.16.1",
-        "@jimp/png": "^0.16.1",
-        "@jimp/tiff": "^0.16.1",
-        "timm": "^1.6.1"
-      }
-    },
-    "@jimp/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -17659,9 +16575,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -17792,9 +16708,9 @@
       "optional": true
     },
     "@nft/email-connector": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@nft/email-connector/-/email-connector-1.0.0-beta.2.tgz",
-      "integrity": "sha512-40N4BnUUkGiVPkQIiCAA5VAmz9D45mUgObryw/zetr+/xUe7wRrS/L3lH+6H75esCrgZukpGsL8HVJZkn4RZ2Q==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nft/email-connector/-/email-connector-1.0.0-beta.4.tgz",
+      "integrity": "sha512-tp24khroV2T5FkxXi7uu7CVJZA14SgbbcOPpohtoA6jzH3XYcFKwN+5al58uv6B+oS8MJaqyoT6ny+oQdSr08Q==",
       "requires": {
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/magic-connector": "^6.1.9",
@@ -17814,17 +16730,16 @@
       }
     },
     "@nft/hooks": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@nft/hooks/-/hooks-1.0.0-beta.2.tgz",
-      "integrity": "sha512-w+BsV9phA5F4BotSHl1Rr+VLkR2IayVLJe7B3JPpZseuhmoz613pxkjxzq75ARI7t2/tzKK6qRuVfMdfIZqMmA==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nft/hooks/-/hooks-1.0.0-beta.4.tgz",
+      "integrity": "sha512-nABqqFnKlo1UeFC8jIvlEnQvCzFmbH1LVRR3QD76zPL5y9F3rjBRyYq7ZopJuUm1vL5HoXxvj48dvpQ9gZlO6w==",
       "requires": {
-        "@apollo/client": "^3.4.16",
         "@ethersproject/abstract-provider": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.0.14",
         "@ethersproject/address": "^5.5.0",
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/properties": "^5.5.0",
-        "@nft/email-connector": "^1.0.0-beta.2",
+        "@nft/email-connector": "^1.0.0-beta.4",
         "@pinata/ipfs-gateway-tools": "1.1.6",
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/core": "^6.1.9",
@@ -17833,8 +16748,7 @@
         "@web3-react/walletlink-connector": "^6.1.9",
         "bignumber.js": "^9.0.2",
         "dayjs": "^1.11.0",
-        "jimp": "^0.16.1",
-        "next": "^12.1.6",
+        "graphql-request": "^5.0.0",
         "react": "^17.0.2",
         "react-device-detect": "^1.17.0"
       }
@@ -19470,30 +18384,6 @@
         "@web3-react/types": "^6.0.7"
       }
     },
-    "@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
-    "@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -19578,11 +18468,6 @@
       "requires": {
         "color-convert": "^2.0.1"
       }
-    },
-    "any-base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -19738,6 +18623,11 @@
       "requires": {
         "tslib": "^2.0.0"
       }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "atob": {
       "version": "2.1.2",
@@ -19957,11 +18847,6 @@
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
-    "bmp-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
-    },
     "bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -20077,11 +18962,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA=="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -20402,6 +19282,14 @@
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "peer": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -20715,6 +19603,11 @@
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
     "denodeify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
@@ -20775,11 +19668,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -21645,11 +20533,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "exif-parser": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
-      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -21815,6 +20698,11 @@
         }
       }
     },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -21898,11 +20786,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-type": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
-      "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -22010,6 +20893,16 @@
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
       "peer": true
     },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -22098,15 +20991,6 @@
       "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
       "peer": true
     },
-    "gifwrap": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
-      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
-      "requires": {
-        "image-q": "^4.0.0",
-        "omggif": "^1.0.10"
-      }
-    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -22127,15 +21011,6 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.3"
-      }
-    },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
       }
     },
     "globals": {
@@ -22174,6 +21049,17 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "peer": true
+    },
+    "graphql-request": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.0.0.tgz",
+      "integrity": "sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-fetch": "^3.1.5",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      }
     },
     "graphql-tag": {
       "version": "2.12.6",
@@ -22335,14 +21221,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      }
-    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -22374,21 +21252,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
-    },
-    "image-q": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
-      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
-      "requires": {
-        "@types/node": "16.9.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.9.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-          "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
-        }
-      }
     },
     "image-size": {
       "version": "0.6.3",
@@ -22572,11 +21435,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-generator-function": {
       "version": "1.0.10",
@@ -22779,18 +21637,6 @@
         }
       }
     },
-    "jimp": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.1.tgz",
-      "integrity": "sha512-+EKVxbR36Td7Hfd23wKGIeEyHbxShZDX6L8uJkgVW3ESA9GiTEPK08tG1XI2r/0w5Ch0HyJF5kPqF9K7EmGjaw==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "@jimp/custom": "^0.16.1",
-        "@jimp/plugins": "^0.16.1",
-        "@jimp/types": "^0.16.1",
-        "regenerator-runtime": "^0.13.3"
-      }
-    },
     "joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -22803,11 +21649,6 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
     },
     "js-sdsl": {
       "version": "4.1.5",
@@ -23156,21 +21997,6 @@
       "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
       "requires": {
         "immediate": "~3.0.5"
-      }
-    },
-    "load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "mime": "^1.3.4",
-        "parse-bmfont-ascii": "^1.0.3",
-        "parse-bmfont-binary": "^1.0.5",
-        "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
-        "xhr": "^2.0.1",
-        "xtend": "^4.0.0"
       }
     },
     "localforage": {
@@ -24164,19 +22990,18 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "peer": true
     },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "peer": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "peer": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -24186,14 +23011,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "peer": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -24232,6 +23049,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "peer": true,
       "requires": {
         "minimist": "^1.2.6"
       }
@@ -24615,11 +23433,6 @@
         "es-abstract": "^1.19.1"
       }
     },
-    "omggif": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -24667,15 +23480,6 @@
           "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
           "peer": true
         }
-      }
-    },
-    "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
-      "requires": {
-        "@wry/context": "^0.6.0",
-        "@wry/trie": "^0.3.0"
       }
     },
     "optionator": {
@@ -24730,11 +23534,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -24743,30 +23542,6 @@
       "requires": {
         "callsites": "^3.0.0"
       }
-    },
-    "parse-bmfont-ascii": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
-    },
-    "parse-bmfont-binary": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
-    },
-    "parse-bmfont-xml": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz",
-      "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
-      "requires": {
-        "xml-parse-from-string": "^1.0.0",
-        "xml2js": "^0.4.5"
-      }
-    },
-    "parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parseurl": {
       "version": "1.3.3",
@@ -24819,11 +23594,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "phin": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
-      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -24844,14 +23614,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "peer": true
-    },
-    "pixelmatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
-      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
-      "requires": {
-        "pngjs": "^3.0.0"
-      }
     },
     "pngjs": {
       "version": "3.4.0",
@@ -24891,11 +23653,6 @@
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -24925,6 +23682,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -25400,11 +24158,6 @@
       "requires": {
         "ret": "~0.1.10"
       }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.20.2",
@@ -26151,11 +24904,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
-    "symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
-    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -26244,11 +24992,6 @@
         }
       }
     },
-    "timm": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
-    },
     "tiny-invariant": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -26258,11 +25001,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tmpl": {
       "version": "1.0.5",
@@ -26330,14 +25068,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -26622,14 +25352,6 @@
         "node-gyp-build": "^4.3.0"
       }
     },
-    "utif": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
-      "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
-      "requires": {
-        "pako": "^1.0.5"
-      }
-    },
     "util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -26812,36 +25534,6 @@
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
       "requires": {}
     },
-    "xhr": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "requires": {
-        "global": "~4.4.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "xml-parse-from-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -26895,19 +25587,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
-    },
-    "zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "requires": {
-        "zen-observable": "0.8.15"
-      }
     },
     "zustand": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "lint": "next lint && prettier \"**/*.{ts,tsx,json,md}\" --check"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
-    "@nft/hooks": "^1.0.0-beta.2",
+    "@nft/hooks": "^1.0.0-beta.4",
     "@rainbow-me/rainbowkit": "^0.5.1",
     "@tanstack/react-query": "^4.2.3",
     "ethers": "^5.7.0",
+    "graphql-tag": "^2.12.6",
     "next": "^12.1.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,5 @@
 import styles from '../styles/app.module.css'
 import { ConnectButton } from '@rainbow-me/rainbowkit'
-import { setContext } from '@apollo/client/link/context'
-import {
-  ApolloClient,
-  ApolloProvider,
-  createHttpLink,
-  InMemoryCache,
-} from '@apollo/client'
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit'
 import '@rainbow-me/rainbowkit/styles.css'
 import { AppProps } from 'next/app'
@@ -19,8 +12,9 @@ import {
   useDisconnect,
 } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
-import { PropsWithChildren, useEffect } from 'react'
+import { PropsWithChildren } from 'react'
 import { useAuthenticate } from '@nft/hooks'
+import { LiteflowProvider } from '@nft/hooks'
 
 const { chains, provider } = configureChains(
   [chain[process.env.NEXT_PUBLIC_CHAIN_NAME]], // Pass the name of the Wagmi supported chain. See "chain" types or (https://wagmi.sh/docs/providers/configuring-chains#chains)
@@ -36,28 +30,6 @@ const wagmiClient = createClient({
   autoConnect: true,
   connectors,
   provider,
-})
-
-const authLink = setContext((_, context) => {
-  const address = localStorage.getItem('authorization.address')
-  const authorization = localStorage.getItem(`authorization.${address}`)
-  if (!authorization) return context
-  return {
-    ...context,
-    headers: {
-      ...context.headers,
-      authorization: `Bearer ${authorization}`,
-    },
-  }
-})
-
-const apolloClient = new ApolloClient({
-  link: authLink.concat(
-    createHttpLink({
-      uri: process.env.NEXT_PUBLIC_ENDPOINT, // Pass the API endpoint of your app
-    }),
-  ),
-  cache: new InMemoryCache({}),
 })
 
 function AccountManager(props: PropsWithChildren) {
@@ -102,18 +74,18 @@ function AccountManager(props: PropsWithChildren) {
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
-    <ApolloProvider client={apolloClient}>
-      <WagmiConfig client={wagmiClient}>
-        <RainbowKitProvider chains={chains} coolMode>
+    <WagmiConfig client={wagmiClient}>
+      <RainbowKitProvider chains={chains} coolMode>
+        <LiteflowProvider endpoint={process.env.NEXT_PUBLIC_ENDPOINT}>
           <AccountManager>
             <div className={styles.app}>
               <ConnectButton />
               <Component {...pageProps} />
             </div>
           </AccountManager>
-        </RainbowKitProvider>
-      </WagmiConfig>
-    </ApolloProvider>
+        </LiteflowProvider>
+      </RainbowKitProvider>
+    </WagmiConfig>
   )
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -31,7 +31,7 @@ const wagmiClient = createClient({
   provider,
 })
 
-function AccountManager(props: PropsWithChildren) {
+function AccountProvider(props: PropsWithChildren) {
   const [authenticate, { setAuthenticationToken, resetAuthenticationToken }] =
     useAuthenticate()
   const { disconnect } = useDisconnect()
@@ -80,12 +80,12 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     <WagmiConfig client={wagmiClient}>
       <RainbowKitProvider chains={chains} coolMode>
         <LiteflowProvider endpoint={process.env.NEXT_PUBLIC_ENDPOINT}>
-          <AccountManager>
+          <AccountProvider>
             <div className={styles.app}>
               <ConnectButton />
               <Component {...pageProps} />
             </div>
-          </AccountManager>
+          </AccountProvider>
         </LiteflowProvider>
       </RainbowKitProvider>
     </WagmiConfig>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -42,6 +42,7 @@ function AccountManager(props: PropsWithChildren) {
         localStorage.getItem('authorization.address') === address &&
         localStorage.getItem(`authorization.${address}`)
       ) {
+        // since the user is already authenticated we can autoconnect
         setAuthenticationToken(localStorage.getItem(`authorization.${address}`))
         // TODO: should check the expiration date of the jwt token to make sure it's still valid
         return
@@ -63,7 +64,7 @@ function AccountManager(props: PropsWithChildren) {
         })
     },
     onDisconnect() {
-      // remove authorization data
+      // remove authorization and authentication data
       const address = localStorage.getItem('authorization.address')
       localStorage.removeItem(`authorization.${address}`)
       localStorage.removeItem('authorization.address')

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,8 +13,7 @@ import {
 } from 'wagmi'
 import { publicProvider } from 'wagmi/providers/public'
 import { PropsWithChildren } from 'react'
-import { useAuthenticate } from '@nft/hooks'
-import { LiteflowProvider } from '@nft/hooks'
+import { LiteflowProvider, useAuthenticate } from '@nft/hooks'
 
 const { chains, provider } = configureChains(
   [chain[process.env.NEXT_PUBLIC_CHAIN_NAME]], // Pass the name of the Wagmi supported chain. See "chain" types or (https://wagmi.sh/docs/providers/configuring-chains#chains)
@@ -33,7 +32,8 @@ const wagmiClient = createClient({
 })
 
 function AccountManager(props: PropsWithChildren) {
-  const [authenticate] = useAuthenticate()
+  const [authenticate, { setAuthenticationToken, resetAuthenticationToken }] =
+    useAuthenticate()
   const { disconnect } = useDisconnect()
   useAccount({
     async onConnect({ address, connector }) {
@@ -42,6 +42,7 @@ function AccountManager(props: PropsWithChildren) {
         localStorage.getItem('authorization.address') === address &&
         localStorage.getItem(`authorization.${address}`)
       ) {
+        setAuthenticationToken(localStorage.getItem(`authorization.${address}`))
         // TODO: should check the expiration date of the jwt token to make sure it's still valid
         return
       }
@@ -66,6 +67,7 @@ function AccountManager(props: PropsWithChildren) {
       const address = localStorage.getItem('authorization.address')
       localStorage.removeItem(`authorization.${address}`)
       localStorage.removeItem('authorization.address')
+      resetAuthenticationToken()
     },
   })
 


### PR DESCRIPTION
Updated `@nft/hooks` to version `beta.4` and updated the code example and its updated dependencies.

related: https://github.com/liteflow-labs/nft/issues/2193

NOTE: During update I noticed that we are missing a dependency of `graphql-tag` inside `@nft/hooks`. Therefore the dependency was added to this PR to get the app working but I will create a PR for `@nft/hooks` to fix that issue as well as this issue [#19](https://github.com/liteflow-labs/minimal-app/issues/19) to remove that dependency once the package has been updated.